### PR TITLE
Update test_that_it_should_get_hyphen_below_string

### DIFF
--- a/test/jay_flavored_markdown_test.rb
+++ b/test/jay_flavored_markdown_test.rb
@@ -13,7 +13,7 @@ class JayFlavoredMarkdownTest < Minitest::Test
   end
 
   #文字列の下行の '-' の入力が，2段階見出しの出力になる問題を検証するテスト
-  def test_that_it_should_get_hyphen_below_string
+  def test_that_it_should_get_two_level_heading
     assert_equal JayFlavoredMarkdownToPlainTextConverter.new("aaa\n-").content, "1.1 aaa"
   end
 


### PR DESCRIPTION
#2 (JFM の文字列の下行の '-' の入力が，2段階見出しの出力になる問題を検証するテストが通るように改良する) に対するPR

文字列の下行の '-' の入力によって，2段階見出しの出力になることは Markdown における仕様である．
このため，test/jay_flavored_markdown_test.rb に対し，テスト結果を上記の仕様が確認できるように変更した．