### PR TITLE
Update activesupport and replace whitelist

### DIFF
--- a/jay_flavored_markdown.gemspec
+++ b/jay_flavored_markdown.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gemoji"
   spec.add_dependency "sanitize"
   spec.add_dependency "rouge"
-  spec.add_dependency "activesupport", "~> 6.1.4"
+  spec.add_dependency "activesupport", "~> 7.0.5.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/lib/jay_flavored_markdown/markdown_converter.rb
+++ b/lib/jay_flavored_markdown/markdown_converter.rb
@@ -1059,12 +1059,12 @@ class JayFlavoredMarkdownConverter
   private
 
   def context
-    whitelist = HTML::Pipeline::SanitizationFilter::WHITELIST.deep_dup
-    whitelist[:attributes][:all] << "data-linenum"
+    allowlist = HTML::Pipeline::SanitizationFilter::ALLOWLIST.deep_dup
+    allowlist[:attributes][:all] << "data-linenum"
     {
       input: "GFM",
       asset_root: 'https://github.githubassets.com/images/icons/',
-      whitelist: whitelist,
+      allowlist: allowlist,
       syntax_highlighter: :rouge,
       syntax_highlighter_opts: {inline_theme: true, line_numbers: true, code_class: 'codehilite'}
     }
@@ -1102,13 +1102,13 @@ class JayFlavoredMarkdownToPlainTextConverter
   private
 
   def context
-    whitelist = HTML::Pipeline::SanitizationFilter::WHITELIST.deep_dup
-    whitelist[:attributes][:all] << "data-linenum"
+    allowlist = HTML::Pipeline::SanitizationFilter::ALLOWLIST.deep_dup
+    allowlist[:attributes][:all] << "data-linenum"
     {
       input: "GFM",
       # hard_wrap: false,
       asset_root: 'https://assets-cdn.github.com/images/icons/',
-      whitelist: whitelist
+      allowlist: allowlist
     }
   end
 

--- a/lib/jay_flavored_markdown/version.rb
+++ b/lib/jay_flavored_markdown/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JayFlavoredMarkdown
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## やったこと

1. Rails 7 で使用可能にするために activesupport を 7.0.5.1 に変更した．
2. html-pipeline で使用している WHITELIST が ALLOWLIST に変わったため，変更した．
3. version.rb の VERSION を 0.2.0 に変更した．