### PR TITLE
Update gemspec for using jay_flavored_markdown in rails7.2.2

### DIFF
--- a/jay_flavored_markdown.gemspec
+++ b/jay_flavored_markdown.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gemoji"
   spec.add_dependency "sanitize"
   spec.add_dependency "rouge"
-  spec.add_dependency "activesupport", "~> 7.0.5.1"
+  spec.add_dependency "activesupport", ">= 7.1"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
## 変更点
Rails7.2.2で使用可能にするために activesupport を 7.2.2 に変更した．