### PR TITLE
Fix a bug for using greedy match to get indent width

### DIFF
--- a/lib/jay_flavored_markdown/markdown_converter.rb
+++ b/lib/jay_flavored_markdown/markdown_converter.rb
@@ -830,7 +830,7 @@ class JayFillColumns < HTML::Pipeline::TextFilter
     #                         ^
     # Example2: " (A) This is ...."
     #                ^
-    if /(\A\s*([^\s]+ ::|\(.+\)) +)/ =~ str
+    if /(\A\s*([^\s]+ ::|\(.*?\)) +)/ =~ str
       return str_mb_width($1)
     else
       return 0


### PR DESCRIPTION
## Overview
### Before:
+ Using greedy match to get indent width when wrapping line
+ Example:
  ```
  + xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  ```
  + This is converted to:
  ```
  (A) xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      xxxxxxxxxxxx
  ```
      
  + However, in below case...
  ```
  + xxxxxxxxxxxxxxxxxxxx (foo) xxxxxxxxxxxxxx
  ```
  + Internaly, this is converted to
  ```
  (A) xxxxxxxxxxxxxxxxxxxx (foo) xxxxxxxxxxxxxx
  ↑    greedy  match result    ↑
  ```
  + So, this becomes
  ```
  (A) xxxxxxxxxxxxxxxxxxxx (foo) xxxxxxx
                                 xxxxxxx
  ```
+ And, this indent mistake cause a bug because
    + If `paragraph_position` (L. 828) sets `position` to exceed max_width, infinity recursive calls occurs in `fill_column` (L. 856)

 ### After:
+ Fix regex to use lazy match (`.+` -> `.*?`)
+ Example:
  ```
  (A) xxxxxxxxxxxxxxxxxxxx (foo) xxxxxxxxxxxxxx
  ↑ ↑ match
  ```
  +  This is converted to
  ```
  (A) xxxxxxxxxxxxxxxxxxxx (foo) xxxxxxx
      xxxxxxx
  ```

+ And, fix rege from `.+` -> `.*` so that regex matches even when the parentheses are empty